### PR TITLE
Fixed bugs in deployment.md

### DIFF
--- a/src/automation/cost-center/deployment.md
+++ b/src/automation/cost-center/deployment.md
@@ -100,6 +100,11 @@ az network vnet create -g $RESOURCE_GROUP -n <vnetname>
 ```
 Note that this resource group is the same as the one with the policy rules set above.
 
-### Verify automation (troubleshooting)
+### Troubleshooting
 
-You should receive email notifications for every resource you create in the monitored resource group. If you don't receive it, login to [Azure Portal](portal.azure.com), navigate to the Logic App created in the automation resource, and click on the input and output connectors. Both of them might need to be additionally signed in and authenticated, depending on your tenant's AAD settings. Once done, restart the logic app, and create another resource to verify.
+You should receive email notifications for every resource you create in the monitored resource group. 
+
+If you don't receive it, try following troubleshooting steps:
+
+1) Sign in to Logic App connectors: Login to [Azure Portal](portal.azure.com), navigate to the Logic App created in the automation resource, click Edit, and in the Logic App Designer, click on the input and output connectors. Both of them might need to be additionally signed in and authenticated, depending on your tenant's AAD settings. Once done, restart the logic app, and create another resource to verify.
+2) Make sure the right subscription is used in the Logic App input connector (azureeventgrid): In the Logic App Designer, open the input connector ("When a resource event occurs", click on the *Subscription*, and if Fx(Subscription) shows up, remove it, and select the correct subscription from the drop down. This bug will be fixed in the next iteration.

--- a/src/automation/cost-center/deployment.md
+++ b/src/automation/cost-center/deployment.md
@@ -6,6 +6,7 @@ This project contains an automation workflow for cost center tagging, using Serv
 
 - Azure subscription
 - [Azure Function Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local#v2)
+- [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
 
 ## Deploy the cost center automation artifacts
 
@@ -17,23 +18,17 @@ Clone the repo locally
 git clone https://github.com/mspnp/serverless-automation
 ```
 
-The deployment steps shown here use bash shell commands. On Windows, you can use the [Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl/about) to run Bash.
+The deployment steps shown here use bash shell commands. On Windows, you can use the [Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl/about) to run Bash. [Login to your Azure subscription](https://docs.microsoft.com/cli/azure/authenticate-azure-cli?view=azure-cli-latest) before starting.
 
 ### Export the automation variables representing the assets
 
 ```bash
-export $SUBSCRIPTION_ID=<subscription-id>
+export SUBSCRIPTION_ID=<subscription-id>
 export RESOURCE_GROUP=<resource-group-name>
 export LOCATION=<resource-group-location>
 export STORAGE_ACCOUNT_NAME=<storageaccountname>
 export APPSERVICE_NAME=<appservice-name>
 export FUNCAPP_NAME=<funcapp-name>
-```
-
-### Deploy the logic app
-
-```bash
-az group deployment create -g $RESOURCE_GROUP --template-file .\logicApp\template.json  
 ```
 
 ### Deploy the azure function that responds to the logic app
@@ -43,11 +38,13 @@ az group create -n $RESOURCE_GROUP -l $LOCATION \
 && az storage account create -g $RESOURCE_GROUP -n $STORAGE_ACCOUNT_NAME --sku Standard_LRS \
 && az appservice plan create --name $APPSERVICE_NAME -g $RESOURCE_GROUP --sku S1 \
 && az functionapp create -g $RESOURCE_GROUP -n $FUNCAPP_NAME -s $STORAGE_ACCOUNT_NAME --plan $APPSERVICE_NAME \
-&& : turn on system assigned managed identity (MSI) \
+&& : turn on system assigned managed identity \
 && az functionapp identity assign -g $RESOURCE_GROUP -n $FUNCAPP_NAME
 ```
 
 ### Grant azure function resource policy access to the resource group
+
+Replace the <serviceprincipalid> with the service principal ID obtained from the *az functionapp identity assign* command:
 
 ```bash
 az role assignment create --assignee-object-id <serviceprincipalid> \
@@ -70,6 +67,8 @@ az policy definition create --name appendTagsIfNotExists \
 
 ### Enforce policy rules at the resource group level
 
+Note that this resource group could be different from the automation resource group.
+
 ```bash
 az policy assignment create --name billingPolicy \
                             --display-name "Resource billing policy" \
@@ -83,3 +82,24 @@ az policy assignment create --name billingPolicy \
 cd ./src/automation/cost-center/cost-center-tagging
 func azure functionapp publish $FUNCAPP_NAME
 ```
+
+### Deploy the logic app
+
+On command line, navigate to /src/automation/cost-center/cost-center-tagging/ and run this command:
+
+```bash
+az group deployment create -g $RESOURCE_GROUP --template-file ./logicApp/template.json --parameters ReactorFunctionName=$FUNCAPP_NAME
+```
+
+### Deploy a resource to tag
+
+Run any resource creation command on Azure CLI, such as:
+
+```bash
+az network vnet create -g $RESOURCE_GROUP -n <vnetname>
+```
+Note that this resource group is the same as the one with the policy rules set above.
+
+### Verify automation (troubleshooting)
+
+You should receive email notifications for every resource you create in the monitored resource group. If you don't receive it, login to [Azure Portal](portal.azure.com), navigate to the Logic App created in the automation resource, and click on the input and output connectors. Both of them might need to be additionally signed in and authenticated, depending on your tenant's AAD settings. Once done, restart the logic app, and create another resource to verify.


### PR DESCRIPTION
The following has been fixed in this PR: 

1) export $SubscriptionID ---> $ removed, does not work with it.
2) Install Azure CLI and login to your subscription - very important step.
3) Reordered the "Deploy Logic App" step as the step to perform AFTER "Publish the function app".
4) In the "Deploy Logic App", the path is corrected to conform to Linux bash (requires forward slashes).
5) In the "Deploy Logic App", added instructions to change to the right directory.
6) Removed "(MSI)" from the "Deploy the azure function..." commands. Linux bash did not recognize that.
7) Added instructions to find the service principal id to be used in "Grant azure function resource policy ... "
8) Added note about using different resource group to set the tagging policy.
9) Added the last step to test this deployment.
10) Added troubleshooting steps - these were blocking issues: 
      (a) both the input and output connectors to the Logic App required to be signed in via the portal. I'm not sure if this is Microsoft tenant specific, and so did not spend time finding out the Azure CLI equivalent.
      (b) Fx(Subscription) appears for the *Subscription* field of the input connector to Logic App. Work item to fix this bug in the template.json has been created, and assigned to Kirpa. 